### PR TITLE
Reagents bank toggle in Bagnon bank menu

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -5,7 +5,7 @@
 
 local CONFIG, Config = ...
 Config.addon = 'Bagnon'
-Config.displayRowHeight = 70
+Config.displayRowHeight = 105
 Config.components = true
 Config.colors = true
 Config.columns = true


### PR DESCRIPTION
I have now implemented a reagents bank toggle for the Bagnon bank menu, as described in my feature request from last week (https://github.com/tullamods/Bagnon/issues/795). This required modifications in Bagnon, Wildpants, Bagnon_Config and Wildpants_Config. (See my other pull requests.)

I hope my coding was conform with what you were intending with your code. Otherwise please let me know!